### PR TITLE
Fixing use of `iptables` without `-w10`

### DIFF
--- a/one-flush-iptables.sh
+++ b/one-flush-iptables.sh
@@ -80,7 +80,7 @@ if [ "x${DOMAIN}" != 'x' ]; then
 	iptables_clean "${DOMAIN}"
 else
 	DOMAINS=( $(virsh -r list --name) )
-	for DOMAIN in $(iptables -L | sed -e "s/^.*\(one-[0-9]*\)-.*$/\1/;tx;d;:x" | sort -u); do
+	for DOMAIN in $(${IPTABLES} -L | sed -e "s/^.*\(one-[0-9]*\)-.*$/\1/;tx;d;:x" | sort -u); do
 		case "${DOMAINS[@]}" in *"${DOMAIN}"*) continue;; esac
 		iptables_clean "${DOMAIN}"
 	done


### PR DESCRIPTION
On busy systems, this causes annoying messages (=> e-mails) from cron:
```
Another app is currently holding the xtables lock. Perhaps you want to use the -w option?
```