### PR TITLE
Disable DNS resolving for iptables

### DIFF
--- a/one-flush-iptables.sh
+++ b/one-flush-iptables.sh
@@ -35,7 +35,7 @@ else
 fi
 
 NAME=$(basename ${0})
-IPTABLES='iptables -w10'
+IPTABLES='iptables -w10 -n'
 DOMAIN="${1}"
 
 #####


### PR DESCRIPTION
Prevents unnecessary hold-ups and locks when listing iptables.