### PR TITLE
Disable DNS resolving for iptables

### DIFF
--- a/one-flush-iptables.sh
+++ b/one-flush-iptables.sh
@@ -80,7 +80,7 @@ if [ "x${DOMAIN}" != 'x' ]; then
 	iptables_clean "${DOMAIN}"
 else
 	DOMAINS=( $(virsh -r list --name) )
-	for DOMAIN in $(${IPTABLES} -L | sed -e "s/^.*\(one-[0-9]*\)-.*$/\1/;tx;d;:x" | sort -u); do
+	for DOMAIN in $(${IPTABLES} -n -L | sed -e "s/^.*\(one-[0-9]*\)-.*$/\1/;tx;d;:x" | sort -u); do
 		case "${DOMAINS[@]}" in *"${DOMAIN}"*) continue;; esac
 		iptables_clean "${DOMAIN}"
 	done


### PR DESCRIPTION
Prevents unnecessary hold-ups and lock-ups when listing iptables chains.